### PR TITLE
Fix: Adding auto-generated indexes

### DIFF
--- a/generate_indexes.sh
+++ b/generate_indexes.sh
@@ -1,12 +1,7 @@
 #!/bin/bash
 
-version=$(git describe --tags)
-header="Cantus Editor"
+version=$(git describe --tags --always)
+header="CantusEditor"
 
 # Generate the index for the mei folder
-python3 make_index.py ./resources/mei --header $header --version $version > ./resources/index.html
-
-
-# Generate the index for the mei folder
-python3 make_index.py ./meix.js/validation --header $header --version $version > ./meix.js/validation/index.html
-
+python3 make_index.py --header "$header" --version "$version" "./resources/mei/" > ./resources/mei/index.html

--- a/generate_indexes.sh
+++ b/generate_indexes.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+version=$(git describe --tags)
+header="Cantus Editor"
+
+# Generate the index for the mei folder
+python3 make_index.py ./resources/mei --header $header --version $version > ./resources/index.html
+
+
+# Generate the index for the mei folder
+python3 make_index.py ./meix.js/validation --header $header --version $version > ./meix.js/validation/index.html
+

--- a/make_index.py
+++ b/make_index.py
@@ -1,0 +1,48 @@
+""" Build index from directory listing
+
+make_index.py </path/to/directory> [--header <header text>]
+"""
+import os
+import argparse
+
+# May need to do "pip install mako"
+from mako.template import Template
+
+
+INDEX_TEMPLATE = r"""
+<html>
+<body>
+<h2>${header}</h2>
+<p>This index has been generated automatically<p>
+<p>Version: ${version}<p>
+<p>
+% for name in names:
+    <li><a href="${name}">${name}</a></li>
+% endfor
+</p>
+</body>
+</html>
+"""
+
+EXCLUDED = ['index.html']
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("directory")
+    parser.add_argument("--header")
+    parser.add_argument("--version")
+    args = parser.parse_args()
+    fnames = [fname for fname in sorted(os.listdir(args.directory))
+              if fname not in EXCLUDED]
+    header = (args.header if args.header else os.path.basename(args.directory))
+    version = (args.version if args.version else "unknown")
+    t = Template(INDEX_TEMPLATE).render(
+        names=fnames,
+        header=header,
+        version=version)
+    print(t)
+
+
+if __name__ == '__main__':
+    main()

--- a/resources/mei/index.html
+++ b/resources/mei/index.html
@@ -1,0 +1,19 @@
+
+<html>
+<body>
+<h2>CantusEditor</h2>
+<p>This index has been generated automatically<p>
+<p>Version: v0.1.0-2-g581191c<p>
+<p>
+    <li><a href="README.md">README.md</a></li>
+    <li><a href="csg-0390_007.mei">csg-0390_007.mei</a></li>
+    <li><a href="csg-0390_008.mei">csg-0390_008.mei</a></li>
+    <li><a href="csg-0390_009.mei">csg-0390_009.mei</a></li>
+    <li><a href="csg-0390_010.mei">csg-0390_010.mei</a></li>
+    <li><a href="csg-0390_014.mei">csg-0390_014.mei</a></li>
+    <li><a href="csg-0390_015.mei">csg-0390_015.mei</a></li>
+    <li><a href="csg-0390_016.mei">csg-0390_016.mei</a></li>
+</p>
+</body>
+</html>
+


### PR DESCRIPTION
Adding auto-generated indexes, and the scripts to generate them, in order to solve problems with the production environment of gh-pages which does not expose the list of files inside a folder of the website.