### PR TITLE
Validating index.html files

### DIFF
--- a/make_index.py
+++ b/make_index.py
@@ -9,17 +9,21 @@ import argparse
 from mako.template import Template
 
 
-INDEX_TEMPLATE = r"""
-<html>
+INDEX_TEMPLATE = r"""<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>${header}</title>
+</head>
 <body>
-<h2>${header}</h2>
-<p>This index has been generated automatically<p>
-<p>Version: ${version}<p>
-<p>
-% for name in names:
-    <li><a href="${name}">${name}</a></li>
-% endfor
-</p>
+    <h2>${header}</h2>
+    <p>This index has been generated automatically<p>
+    <p>Version: ${version}<p>
+    <ul>
+    % for name in names:
+        <li><a href="${name}">${name}</a></li>
+    % endfor
+    </ul>
 </body>
 </html>
 """

--- a/resources/mei/index.html
+++ b/resources/mei/index.html
@@ -1,19 +1,23 @@
-
-<html>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>CantusEditor</title>
+</head>
 <body>
-<h2>CantusEditor</h2>
-<p>This index has been generated automatically<p>
-<p>Version: v0.1.0-2-g581191c<p>
-<p>
-    <li><a href="README.md">README.md</a></li>
-    <li><a href="csg-0390_007.mei">csg-0390_007.mei</a></li>
-    <li><a href="csg-0390_008.mei">csg-0390_008.mei</a></li>
-    <li><a href="csg-0390_009.mei">csg-0390_009.mei</a></li>
-    <li><a href="csg-0390_010.mei">csg-0390_010.mei</a></li>
-    <li><a href="csg-0390_014.mei">csg-0390_014.mei</a></li>
-    <li><a href="csg-0390_015.mei">csg-0390_015.mei</a></li>
-    <li><a href="csg-0390_016.mei">csg-0390_016.mei</a></li>
-</p>
+    <h2>CantusEditor</h2>
+    <p>This index has been generated automatically<p>
+    <p>Version: v0.1.0-6-g9ce18fa<p>
+    <ul>
+        <li><a href="README.md">README.md</a></li>
+        <li><a href="csg-0390_007.mei">csg-0390_007.mei</a></li>
+        <li><a href="csg-0390_008.mei">csg-0390_008.mei</a></li>
+        <li><a href="csg-0390_009.mei">csg-0390_009.mei</a></li>
+        <li><a href="csg-0390_010.mei">csg-0390_010.mei</a></li>
+        <li><a href="csg-0390_014.mei">csg-0390_014.mei</a></li>
+        <li><a href="csg-0390_015.mei">csg-0390_015.mei</a></li>
+        <li><a href="csg-0390_016.mei">csg-0390_016.mei</a></li>
+    </ul>
 </body>
 </html>
 


### PR DESCRIPTION
The auto-generated index.html files are still not being served by GitHub pages, some other people have been successful by verifying the html files do not throw any errors/warnings if they are validated against html validators. Making sure our auto-generated indexes comply.